### PR TITLE
Do not execute default target if ILRepack.targets exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@
 [Rr]eleases/
 x64/
 x86/
-build/
 bld/
 [Bb]in/
 [Oo]bj/

--- a/ILRepack.Lib.MSBuild/build/ILRepack.Lib.MSBuild.targets
+++ b/ILRepack.Lib.MSBuild/build/ILRepack.Lib.MSBuild.targets
@@ -7,7 +7,7 @@
     <ILRepackMsBuildPath Condition=" '$(ILRepackMsBuildPath)' == '' And '$(MSBuildRuntimeType)' != 'Core' ">$(MSBuildThisFileDirectory)\..\tools\net461\ILRepack.Lib.MSBuild.dll</ILRepackMsBuildPath>
 
     <ILRepackTargetsFile Condition=" '$(ILRepackTargetsFile)' == '' ">$(ProjectDir)ILRepack.targets</ILRepackTargetsFile>
-    <DoILRepack Condition=" '$(DoILRepack)' == '' and $(Configuration.Contains('Release')) ">true</DoILRepack>
+    <DoILRepack Condition=" '$(DoILRepack)' == '' and $(Configuration.Contains('Release')) and !Exists('$(ILRepackTargetsFile)') ">true</DoILRepack>
     <ILRepackInternalize Condition=" '$(ILRepackInternalize)' == '' and '$(TargetExt)' == '.exe'">true</ILRepackInternalize>
   </PropertyGroup>
   


### PR DESCRIPTION
Currently it's executing two times the ILRepack which was leading to duplicated symbols.